### PR TITLE
part04: replace legacy backticks and 'expr'

### DIFF
--- a/Basic-Script-Bulding/part04-Math-Example.sh
+++ b/Basic-Script-Bulding/part04-Math-Example.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# An example of using the expr command
+# An example of a simple division
 
 var1=10
 var2=20
-var3=`expr $var2 / $var1`
-echo The result is $var3
+var3=$(( $var2 / $var1 ))
+echo "'$var2' divided by '$var1' results in '$var3'"

--- a/Basic-Script-Bulding/part06-Double-Parentheses-Command-Symbols.sh
+++ b/Basic-Script-Bulding/part06-Double-Parentheses-Command-Symbols.sh
@@ -3,8 +3,8 @@
 # using double parenthesis
 
 val1=10
-if (( $val1 ** 2 > 90 ))
-then
-(( val2 = $val1 ** 2 ))
-echo "The square of $val1 is $val2"
+
+if (( val1 ** 2 > 90 )); then
+  (( val2 = val1 ** 2 ))
+  echo "The square of '$val1' is '$val2'"
 fi


### PR DESCRIPTION
Running 'shellcheck' on the file would reveal the following two messages:

>   SC2006 (style): Use $(...) notation instead of legacy backticks \`...\`.
>   SC2003 (style): expr is antiquated. Consider rewriting this using  $((..)), ${} or [[ ]].

To read more about each shellcheck message, you may visit the following URL where XXXX is the number given in the message:

   https://www.shellcheck.net/wiki/SCXXXX

For example, in this case:

   https://www.shellcheck.net/wiki/SC2003
   https://www.shellcheck.net/wiki/SC2006